### PR TITLE
Calculate base number of tasks.

### DIFF
--- a/provider/swarm_test.go
+++ b/provider/swarm_test.go
@@ -16,3 +16,28 @@ func TestTaskCannotScaleDownBecauseItHasNotEnoughTaskRunning(t *testing.T) {
 		t.Errorf("It can not scale")
 	}
 }
+
+func TestExcludeUnCountedTasks(t *testing.T) {
+	p := SwarmProvider{}
+	tasks := []swarm.Task{
+		swarm.Task{
+			Status: swarm.TaskStatus{
+				State: swarm.TaskStatePreparing,
+			},
+		},
+		swarm.Task{
+			Status: swarm.TaskStatus{
+				State: swarm.TaskStateRunning,
+			},
+		},
+		swarm.Task{
+			Status: swarm.TaskStatus{
+				State: swarm.TaskStateFailed,
+			},
+		},
+	}
+	n := p.calculateActiveTasks(tasks)
+	if n != 2 {
+		t.Errorf("Tasks need to be two")
+	}
+}


### PR DESCRIPTION
We was counting all the tasks in a service. It means also shotted down
or rejected tasks. This was getting us a bad started point.