### PR TITLE
Add basic CLA and debugging informations

### DIFF
--- a/api/autoscaler-ls.go
+++ b/api/autoscaler-ls.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gianarb/orbiter/autoscaler"
+)
+
+type AutoscalerResponse struct {
+	Name string `json:"name"`
+}
+
+func AutoscalerList(scalers autoscaler.Autoscalers) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		l := []AutoscalerResponse{}
+		for n, _ := range scalers {
+			c := AutoscalerResponse{
+				Name: n,
+			}
+			l = append(l, c)
+		}
+		cc := &CollectionResponse{
+			Data: l,
+		}
+		b, _ := json.Marshal(cc)
+		w.Write(b)
+	}
+}

--- a/api/common.go
+++ b/api/common.go
@@ -1,0 +1,5 @@
+package api
+
+type CollectionResponse struct {
+	Data interface{} `json:"data"`
+}

--- a/api/router.go
+++ b/api/router.go
@@ -9,6 +9,7 @@ import (
 func GetRouter(core core.Core, eventChannel chan *logrus.Entry) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/handle/{autoscaler_name}/{service_name}", Handle(core.Autoscalers)).Methods("POST")
+	r.HandleFunc("/autoscaler", AutoscalerList(core.Autoscalers)).Methods("GET")
 	r.HandleFunc("/health", Health()).Methods("GET")
 	r.HandleFunc("/events", Events(eventChannel)).Methods("GET")
 	return r

--- a/autoscaler/autoscaler.go
+++ b/autoscaler/autoscaler.go
@@ -4,6 +4,7 @@ import "github.com/Sirupsen/logrus"
 
 type Provider interface {
 	Scale(string, int, bool) error
+	Name() string
 }
 
 type Autoscalers map[string]Autoscaler

--- a/cmd/autoscaler-ls.go
+++ b/cmd/autoscaler-ls.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type AutoscalerListCmd struct {
+}
+
+func (c *AutoscalerListCmd) Run(args []string) int {
+	r, err := http.Get(fmt.Sprintf("%s/autoscaler", os.Getenv("ORBITER_HOST")))
+	if err != nil {
+		logrus.Fatal(err)
+		return 1
+	}
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		logrus.Fatal(err)
+		return 1
+	}
+	fmt.Printf("%s\n\r", body)
+	return 0
+}
+
+func (c *AutoscalerListCmd) Help() string {
+	helpText := `
+Usage: List of autoscalers currently enabled.																											`
+	return strings.TrimSpace(helpText)
+}
+
+func (r *AutoscalerListCmd) Synopsis() string {
+	return "List all autoscalers currently managed by orbiter."
+}

--- a/cmd/system-events.go
+++ b/cmd/system-events.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type SystemEventsCmd struct {
+}
+
+func (c *SystemEventsCmd) Run(args []string) int {
+	r, err := http.Get(fmt.Sprintf("%s/events", os.Getenv("ORBITER_HOST")))
+	if err != nil {
+		logrus.Fatal(err)
+		return 1
+	}
+	defer r.Body.Close()
+	reader := bufio.NewReader(r.Body)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			logrus.Fatal(err)
+			return 1
+		}
+		fmt.Printf("%s", line)
+	}
+	return 0
+}
+
+func (c *SystemEventsCmd) Help() string {
+	helpText := `
+Usage: Listen to all the events fired by the daemon`
+	return strings.TrimSpace(helpText)
+}
+
+func (r *SystemEventsCmd) Synopsis() string {
+	return "Listen to all the events fired by the daemon."
+}

--- a/cmd/system-events.go
+++ b/cmd/system-events.go
@@ -29,7 +29,6 @@ func (c *SystemEventsCmd) Run(args []string) int {
 		}
 		fmt.Printf("%s", line)
 	}
-	return 0
 }
 
 func (c *SystemEventsCmd) Help() string {

--- a/main.go
+++ b/main.go
@@ -18,7 +18,9 @@ func main() {
 
 	c.Commands = map[string]cli.CommandFactory{
 		"daemon": func() (cli.Command, error) {
-			return &cmd.DaemonCmd{eventChannel}, nil
+			return &cmd.DaemonCmd{
+				EventChannel: eventChannel,
+			}, nil
 		},
 		"autoscaler ls": func() (cli.Command, error) {
 			return &cmd.AutoscalerListCmd{}, nil

--- a/main.go
+++ b/main.go
@@ -20,6 +20,12 @@ func main() {
 		"daemon": func() (cli.Command, error) {
 			return &cmd.DaemonCmd{eventChannel}, nil
 		},
+		"autoscaler ls": func() (cli.Command, error) {
+			return &cmd.AutoscalerListCmd{}, nil
+		},
+		"system events": func() (cli.Command, error) {
+			return &cmd.SystemEventsCmd{}, nil
+		},
 	}
 
 	exitStatus, _ := c.Run()

--- a/provider/digitalocean.go
+++ b/provider/digitalocean.go
@@ -34,6 +34,10 @@ func NewDigitalOceanProvider(c map[string]string) (autoscaler.Provider, error) {
 	return p, nil
 }
 
+func (p DigitalOceanProvider) Name() string {
+	return "digitalocean"
+}
+
 func (p DigitalOceanProvider) Scale(serviceId string, target int, direction bool) error {
 	var wg sync.WaitGroup
 	responseChannel := make(chan response, target)

--- a/provider/fake.go
+++ b/provider/fake.go
@@ -3,6 +3,10 @@ package provider
 type FakeProvider struct {
 }
 
+func (f FakeProvider) Name() string {
+	return "fake"
+}
+
 func (f FakeProvider) Scale(serviceId string, target int, direction bool) error {
 	return nil
 }

--- a/provider/swarm.go
+++ b/provider/swarm.go
@@ -33,6 +33,10 @@ func NewSwarmProvider(c map[string]string) (autoscaler.Provider, error) {
 
 }
 
+func (p SwarmProvider) Name() string {
+	return "swarm"
+}
+
 func (p SwarmProvider) Scale(serviceId string, target int, direction bool) error {
 	ctx := context.Background()
 	service, _, err := p.dockerClient.ServiceInspectWithRaw(ctx, serviceId)


### PR DESCRIPTION
Add new API call to get all the autoscalers currently managed by
orbiter:

```
curl http://localhost:8000/autoscaler
```

Add command into the CLI to get this list

```
export ORBITER_HOST=http://localhost:8000 orbiter autoscler ls
```

Add command into the CLI to print all the events fired by the daemon:

```
export ORBITER_HOST=http://localhost:8000 orbiter system events
```