### PR TITLE
Change API root path to `/v1/orbiter`

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -8,11 +8,20 @@ import (
 
 func GetRouter(core *core.Core, eventChannel chan *logrus.Entry) *mux.Router {
 	r := mux.NewRouter()
+
+	r.HandleFunc("/v1/orbiter/handle/{autoscaler_name}/{service_name}", Handle(&core.Autoscalers)).Methods("POST")
+	r.HandleFunc("/v1/orbiter/handle/{autoscaler_name}/{service_name}/{direction}", Handle(&core.Autoscalers)).Methods("POST")
+	r.HandleFunc("/v1/orbiter/autoscaler", AutoscalerList(core.Autoscalers)).Methods("GET")
+	r.HandleFunc("/v1/orbiter/health", Health()).Methods("GET")
+	r.HandleFunc("/v1/orbiter/events", Events(eventChannel)).Methods("GET")
+
+	// This lines will be removed October 2017. They are here to offer a soft migation path.
 	r.HandleFunc("/handle/{autoscaler_name}/{service_name}", Handle(&core.Autoscalers)).Methods("POST")
 	r.HandleFunc("/handle/{autoscaler_name}/{service_name}/{direction}", Handle(&core.Autoscalers)).Methods("POST")
 	r.HandleFunc("/autoscaler", AutoscalerList(core.Autoscalers)).Methods("GET")
 	r.HandleFunc("/health", Health()).Methods("GET")
 	r.HandleFunc("/events", Events(eventChannel)).Methods("GET")
+
 	r.NotFoundHandler = NotFound{}
 	return r
 }


### PR DESCRIPTION
The version is something that we need, but I am also happy to add the
application name `orbiter`.

Some companies are grouping all the applications under the same dns with
a proxy. It's useful for them to detect all the `orbiter` api with a
simple regex.

Both of them are working. But please update your scripts to use `/v1/orbiter`